### PR TITLE
F09 parametrized testing

### DIFF
--- a/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/DeleteCommand.java
+++ b/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/DeleteCommand.java
@@ -27,11 +27,11 @@ public class DeleteCommand extends AbstractManagementCommand {
         try {
             timesheetManagementService.delete(month, day);
             return CommandResult.ok(
-                    String.format("The day '%s'.'%s' has been deleted",
+                    String.format("The day '%d.%d' has been deleted",
                             day, month));
         } catch (TimesheetManagementFailedException e) {
             return CommandResult.error(
-                    String.format("The day '%s'.'%s' could not be deleted because of an exception: %s",
+                    String.format("The day '%d.%d' could not be deleted because of an exception: %s",
                             day, month, e.getMessage()));
         }
     }

--- a/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/UpdateEndCommand.java
+++ b/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/UpdateEndCommand.java
@@ -32,11 +32,11 @@ public class UpdateEndCommand extends AbstractManagementCommand {
         try {
             timesheetManagementService.updateEndTime(month, day, end);
             return CommandResult.ok(
-                    String.format("The day '%s'.'%s' has been updated",
+                    String.format("The day '%d.%d' has been updated",
                             day, month));
         } catch (TimesheetManagementFailedException e) {
             return CommandResult.error(
-                    String.format("The day '%s'.'%s' could not be updated because of an exception: %s",
+                    String.format("The day '%d.%d' could not be updated because of an exception: %s",
                             day, month, e.getMessage()));
         }
     }

--- a/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/UpdateFullCommand.java
+++ b/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/UpdateFullCommand.java
@@ -37,11 +37,11 @@ public class UpdateFullCommand extends AbstractManagementCommand {
             timesheetManagementService.updateStartTime(month, day, start);
             timesheetManagementService.updateEndTime(month, day, end);
             return CommandResult.ok(
-                    String.format("The day '%s'.'%s' has been updated",
+                    String.format("The day '%d.%d' has been updated",
                             day, month));
         } catch (TimesheetManagementFailedException e) {
             return CommandResult.error(
-                    String.format("The day '%s'.'%s' could not be updated because of an exception: %s",
+                    String.format("The day '%d.%d' could not be updated because of an exception: %s",
                             day, month, e.getMessage()));
         }
     }

--- a/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/UpdateStartCommand.java
+++ b/how-long-admin/src/main/java/com/h8/howlong/admin/commands/impl/UpdateStartCommand.java
@@ -32,11 +32,11 @@ public class UpdateStartCommand extends AbstractManagementCommand {
         try {
             timesheetManagementService.updateStartTime(month, day, start);
             return CommandResult.ok(
-                    String.format("The day '%s'.'%s' has been updated",
+                    String.format("The day '%d.%d' has been updated",
                             day, month));
         } catch (TimesheetManagementFailedException e) {
             return CommandResult.error(
-                    String.format("The day '%s'.'%s' could not be updated because of an exception: %s",
+                    String.format("The day '%d.%d' could not be updated because of an exception: %s",
                             day, month, e.getMessage()));
         }
     }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/CommandFactoryTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/CommandFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;
+import java.util.Calendar;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +37,7 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.LIST;
-        var month = 10;
+        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
 
         //when
         when(args.getCommand())
@@ -59,8 +60,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.DELETE;
-        var month = 10;
-        var day = 22;
+        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
 
         //when
         when(args.getCommand())
@@ -70,9 +71,7 @@ class CommandFactoryTest {
         when(args.getDay())
                 .thenReturn(day);
 
-
         var c = commandFactory.resolveCommand(args);
-
 
         //then
         assertThat(c).isInstanceOf(DeleteCommand.class);
@@ -91,8 +90,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = 5;
-        var day = 10;
+        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         var startTime = LocalTime.now();
 
         //when
@@ -114,7 +113,6 @@ class CommandFactoryTest {
         assertThat(updateStartCommand.getMonth()).isEqualTo(month);
         assertThat(updateStartCommand.getDay()).isEqualTo(day);
         assertThat(updateStartCommand.getStart()).isEqualTo(startTime);
-
     }
 
     @Test
@@ -122,8 +120,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = 5;
-        var day = 10;
+        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         var endTime = LocalTime.now();
 
         //when
@@ -145,7 +143,6 @@ class CommandFactoryTest {
         assertThat(updateEndCommand.getMonth()).isEqualTo(month);
         assertThat(updateEndCommand.getDay()).isEqualTo(day);
         assertThat(updateEndCommand.getEnd()).isEqualTo(endTime);
-
     }
 
     @Test
@@ -153,8 +150,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = 5;
-        var day = 10;
+        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         var startTime = LocalTime.now().minusHours(1);
         var endTime = LocalTime.now();
 
@@ -181,7 +178,6 @@ class CommandFactoryTest {
         assertThat(updateFullCommand.getStart()).isEqualTo(startTime);
         assertThat(updateFullCommand.getEnd()).isEqualTo(endTime);
     }
-
 
     @Test
     void shouldThrowAnExceptionWhenCommandArgumentCannotBeResolved()
@@ -221,8 +217,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = 5;
-        var day = 10;
+        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         Optional<LocalTime> startTime = Optional.empty();
         Optional<LocalTime> endTime = Optional.empty();
 
@@ -245,6 +241,4 @@ class CommandFactoryTest {
                 .isInstanceOf(ArgumentResolutionFailedException.class)
                 .hasMessage("Could not resolve update command for given combination of arguments");
     }
-
-
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/CommandFactoryTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/CommandFactoryTest.java
@@ -25,11 +25,17 @@ class CommandFactoryTest {
 
     private CommandFactory commandFactory;
 
+    private Integer month;
+    private Integer day;
+
     @BeforeEach
     void setUp() {
         args = mock(ArgumentResolver.class);
         managementService = mock(TimesheetManagementService.class);
         commandFactory = new CommandFactory(managementService);
+        var current = LocalDateTime.now();
+        month = current.getMonthValue();
+        day = current.getDayOfMonth();
     }
 
     @Test
@@ -37,7 +43,6 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.LIST;
-        var month = LocalDateTime.now().getMonthValue();
 
         //when
         when(args.getCommand())
@@ -60,8 +65,6 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.DELETE;
-        var month = LocalDateTime.now().getMonthValue();
-        var day = LocalDateTime.now().getDayOfMonth();
 
         //when
         when(args.getCommand())
@@ -90,8 +93,6 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = LocalDateTime.now().getMonthValue();
-        var day = LocalDateTime.now().getDayOfMonth();
         var startTime = LocalTime.now();
 
         //when
@@ -120,8 +121,6 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = LocalDateTime.now().getMonthValue();
-        var day = LocalDateTime.now().getDayOfMonth();
         var endTime = LocalTime.now();
 
         //when
@@ -150,8 +149,6 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = LocalDateTime.now().getMonthValue();
-        var day = LocalDateTime.now().getDayOfMonth();
         var startTime = LocalTime.now();
         var endTime = LocalTime.now().plusHours(1);
 
@@ -216,8 +213,6 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = LocalDateTime.now().getMonthValue();
-        var day = LocalDateTime.now().getDayOfMonth();
         Optional<LocalTime> startTime = Optional.empty();
         Optional<LocalTime> endTime = Optional.empty();
 

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/CommandFactoryTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/CommandFactoryTest.java
@@ -8,8 +8,8 @@ import com.h8.howlong.admin.utils.ArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Calendar;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +37,7 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.LIST;
-        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        var month = LocalDateTime.now().getMonthValue();
 
         //when
         when(args.getCommand())
@@ -60,8 +60,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.DELETE;
-        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        var month = LocalDateTime.now().getMonthValue();
+        var day = LocalDateTime.now().getDayOfMonth();
 
         //when
         when(args.getCommand())
@@ -90,8 +90,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        var month = LocalDateTime.now().getMonthValue();
+        var day = LocalDateTime.now().getDayOfMonth();
         var startTime = LocalTime.now();
 
         //when
@@ -120,8 +120,8 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        var month = LocalDateTime.now().getMonthValue();
+        var day = LocalDateTime.now().getDayOfMonth();
         var endTime = LocalTime.now();
 
         //when
@@ -150,10 +150,10 @@ class CommandFactoryTest {
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
-        var startTime = LocalTime.now().minusHours(1);
-        var endTime = LocalTime.now();
+        var month = LocalDateTime.now().getMonthValue();
+        var day = LocalDateTime.now().getDayOfMonth();
+        var startTime = LocalTime.now();
+        var endTime = LocalTime.now().plusHours(1);
 
         //when
         when(args.getCommand())
@@ -211,14 +211,13 @@ class CommandFactoryTest {
                 .hasMessage("Unknown command 'command'");
     }
 
-
     @Test
     void shouldThrowAnExceptionForMissingUpdateTimes()
             throws ArgumentResolutionFailedException {
         //given
         var command = HowLongAdminCommand.UPDATE;
-        var month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        var day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        var month = LocalDateTime.now().getMonthValue();
+        var day = LocalDateTime.now().getDayOfMonth();
         Optional<LocalTime> startTime = Optional.empty();
         Optional<LocalTime> endTime = Optional.empty();
 

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/DeleteCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/DeleteCommandTest.java
@@ -24,8 +24,9 @@ class DeleteCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = LocalDateTime.now().getMonthValue();
-        day = LocalDateTime.now().getDayOfMonth();
+        var current = LocalDateTime.now();
+        month = current.getMonthValue();
+        day = current.getDayOfMonth();
         deleteCommand = new DeleteCommand(timesheetManagementService, month, day);
     }
 
@@ -45,7 +46,7 @@ class DeleteCommandTest {
         assertThat(dayCaptor.getValue()).isEqualTo(day);
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' has been deleted", day, month))
+                        String.format("The day '%d.%d' has been deleted", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
 
@@ -61,10 +62,7 @@ class DeleteCommandTest {
         //then
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' could not be deleted because of an exception: test", day, month))
+                        String.format("The day '%d.%d' could not be deleted because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
-
-
-
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/DeleteCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/DeleteCommandTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Calendar;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -22,8 +24,8 @@ class DeleteCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = 9;
-        day = 30;
+        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         deleteCommand = new DeleteCommand(timesheetManagementService, month, day);
     }
 
@@ -36,12 +38,14 @@ class DeleteCommandTest {
         //then
         var monthCaptor = ArgumentCaptor.forClass(Integer.class);
         var dayCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(timesheetManagementService, times(1)).delete(monthCaptor.capture(), dayCaptor.capture());
+        verify(timesheetManagementService, times(1))
+                .delete(monthCaptor.capture(), dayCaptor.capture());
 
         assertThat(monthCaptor.getValue()).isEqualTo(month);
         assertThat(dayCaptor.getValue()).isEqualTo(day);
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' has been deleted")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' has been deleted", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
 
@@ -56,7 +60,8 @@ class DeleteCommandTest {
 
         //then
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' could not be deleted because of an exception: test")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' could not be deleted because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/DeleteCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/DeleteCommandTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.util.Calendar;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -24,8 +24,8 @@ class DeleteCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        month = LocalDateTime.now().getMonthValue();
+        day = LocalDateTime.now().getDayOfMonth();
         deleteCommand = new DeleteCommand(timesheetManagementService, month, day);
     }
 

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/ListCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/ListCommandTest.java
@@ -19,9 +19,9 @@ class ListCommandTest {
     @Test
     void shouldReturnProperlyFormattedTimesheetForAGivenMonth() {
         //given
-        var month = 9;
-        var start = LocalDateTime.of(2018, 9, 23, 1, 1);
-        var end = LocalDateTime.of(2018, 9, 23, 1, 2);
+        var start = LocalDateTime.now();
+        var end = start.plusHours(1);
+        var month = start.getMonthValue();
 
         var timesheetManagementService = mock(TimesheetManagementService.class);
         var listCommand = new ListCommand(timesheetManagementService, month);
@@ -29,7 +29,11 @@ class ListCommandTest {
         var list = List.of(workday);
         var pb = PrintBuilder.builder();
 
-        pb.ln(String.format("Timesheet for: <c2018/%02d>", month) + LS + "<c23> | 01:01:00 | 01:02:00 | 00:01");
+        pb.ln(String.format("Timesheet for: <c%02d/%d>", start.getYear(), month) + LS
+                + String.format("<c%02d> | %02d:%02d:%02d | %02d:%02d:%02d | 01:00",
+                start.getDayOfMonth(),
+                start.getHour(), start.getMinute(), start.getSecond(),
+                end.getHour(), end.getMinute(), end.getSecond()));
 
         //when
         when(timesheetManagementService.getTimesheet(month))

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateEndCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateEndCommandTest.java
@@ -25,9 +25,10 @@ class UpdateEndCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = LocalDateTime.now().getMonthValue();
-        day = LocalDateTime.now().getDayOfMonth();
-        end = LocalTime.now();
+        var current = LocalDateTime.now();
+        end = current.toLocalTime();
+        month = current.getMonthValue();
+        day = current.getDayOfMonth();
         updateEndCommand = new UpdateEndCommand(timesheetManagementService, month, day, end);
     }
 
@@ -49,7 +50,7 @@ class UpdateEndCommandTest {
         assertThat(endCaptor.getValue()).isEqualTo(end);
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' has been updated", day, month))
+                        String.format("The day '%d.%d' has been updated", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
 
@@ -65,7 +66,7 @@ class UpdateEndCommandTest {
         //then
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
+                        String.format("The day '%d.%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateEndCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateEndCommandTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalTime;
+import java.util.Calendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -24,9 +25,9 @@ class UpdateEndCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = 9;
-        day = 30;
-        end = LocalTime.of(1, 1);
+        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        end = LocalTime.now();
         updateEndCommand = new UpdateEndCommand(timesheetManagementService, month, day, end);
     }
 
@@ -40,13 +41,15 @@ class UpdateEndCommandTest {
         var monthCaptor = ArgumentCaptor.forClass(Integer.class);
         var dayCaptor = ArgumentCaptor.forClass(Integer.class);
         var endCaptor = ArgumentCaptor.forClass(LocalTime.class);
-        verify(timesheetManagementService, times(1)).updateEndTime(monthCaptor.capture(), dayCaptor.capture(), endCaptor.capture());
+        verify(timesheetManagementService, times(1))
+                .updateEndTime(monthCaptor.capture(), dayCaptor.capture(), endCaptor.capture());
 
         assertThat(monthCaptor.getValue()).isEqualTo(month);
         assertThat(dayCaptor.getValue()).isEqualTo(day);
         assertThat(endCaptor.getValue()).isEqualTo(end);
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' has been updated")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' has been updated", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
 
@@ -61,7 +64,8 @@ class UpdateEndCommandTest {
 
         //then
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' could not be updated because of an exception: test")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateEndCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateEndCommandTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Calendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -25,8 +25,8 @@ class UpdateEndCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        month = LocalDateTime.now().getMonthValue();
+        day = LocalDateTime.now().getDayOfMonth();
         end = LocalTime.now();
         updateEndCommand = new UpdateEndCommand(timesheetManagementService, month, day, end);
     }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateFullCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateFullCommandTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Calendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -26,10 +26,10 @@ class UpdateFullCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
-        start = LocalTime.of(1, 0);
-        end = LocalTime.of(1, 1);
+        start = LocalTime.now();
+        end = start.plusHours(1);
+        month = LocalDateTime.now().getMonthValue();
+        day = LocalDateTime.now().getDayOfMonth();
         updateFullCommand = new UpdateFullCommand(timesheetManagementService, month, day, start, end);
     }
 

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateFullCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateFullCommandTest.java
@@ -26,10 +26,11 @@ class UpdateFullCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        start = LocalTime.now();
+        var current = LocalDateTime.now();
+        start = current.toLocalTime();
         end = start.plusHours(1);
-        month = LocalDateTime.now().getMonthValue();
-        day = LocalDateTime.now().getDayOfMonth();
+        month = current.getMonthValue();
+        day = current.getDayOfMonth();
         updateFullCommand = new UpdateFullCommand(timesheetManagementService, month, day, start, end);
     }
 
@@ -63,7 +64,7 @@ class UpdateFullCommandTest {
 
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' has been updated", day, month));
+                        String.format("The day '%d.%d' has been updated", day, month));
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
@@ -80,7 +81,7 @@ class UpdateFullCommandTest {
         //then
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
+                        String.format("The day '%d.%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 
@@ -96,7 +97,7 @@ class UpdateFullCommandTest {
         //then
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
+                        String.format("The day '%d.%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateFullCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateFullCommandTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalTime;
+import java.util.Calendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -25,8 +26,8 @@ class UpdateFullCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = 9;
-        day = 30;
+        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         start = LocalTime.of(1, 0);
         end = LocalTime.of(1, 1);
         updateFullCommand = new UpdateFullCommand(timesheetManagementService, month, day, start, end);
@@ -61,7 +62,8 @@ class UpdateFullCommandTest {
 
 
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' has been updated");
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' has been updated", day, month));
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
@@ -77,7 +79,8 @@ class UpdateFullCommandTest {
 
         //then
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' could not be updated because of an exception: test")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 
@@ -92,7 +95,8 @@ class UpdateFullCommandTest {
 
         //then
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' could not be updated because of an exception: test")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateStartCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateStartCommandTest.java
@@ -26,9 +26,10 @@ class UpdateStartCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = LocalDateTime.now().getMonthValue();
-        day = LocalDateTime.now().getDayOfMonth();
-        start = LocalTime.now();
+        var current = LocalDateTime.now();
+        start = current.toLocalTime();
+        month = current.getMonthValue();
+        day = current.getDayOfMonth();
         updateStartCommand = new UpdateStartCommand(timesheetManagementService, month, day, start);
     }
 
@@ -50,7 +51,7 @@ class UpdateStartCommandTest {
         assertThat(startCaptor.getValue()).isEqualTo(start);
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' has been updated", day, month))
+                        String.format("The day '%d.%d' has been updated", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
 
@@ -66,7 +67,7 @@ class UpdateStartCommandTest {
         //then
         assertThat(commandResult)
                 .hasFieldOrPropertyWithValue("message",
-                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
+                        String.format("The day '%d.%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateStartCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateStartCommandTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Calendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -26,9 +26,9 @@ class UpdateStartCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
-        start = LocalTime.of(1, 1);
+        month = LocalDateTime.now().getMonthValue();
+        day = LocalDateTime.now().getDayOfMonth();
+        start = LocalTime.now();
         updateStartCommand = new UpdateStartCommand(timesheetManagementService, month, day, start);
     }
 

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateStartCommandTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/commands/impl/UpdateStartCommandTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalTime;
+import java.util.Calendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
@@ -25,8 +26,8 @@ class UpdateStartCommandTest {
     @BeforeEach
     void setUp() {
         timesheetManagementService = mock(TimesheetManagementService.class);
-        month = 9;
-        day = 30;
+        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
         start = LocalTime.of(1, 1);
         updateStartCommand = new UpdateStartCommand(timesheetManagementService, month, day, start);
     }
@@ -41,13 +42,15 @@ class UpdateStartCommandTest {
         var monthCaptor = ArgumentCaptor.forClass(Integer.class);
         var dayCaptor = ArgumentCaptor.forClass(Integer.class);
         var startCaptor = ArgumentCaptor.forClass(LocalTime.class);
-        verify(timesheetManagementService, times(1)).updateStartTime(monthCaptor.capture(), dayCaptor.capture(), startCaptor.capture());
+        verify(timesheetManagementService, times(1)).
+                updateStartTime(monthCaptor.capture(), dayCaptor.capture(), startCaptor.capture());
 
         assertThat(monthCaptor.getValue()).isEqualTo(month);
         assertThat(dayCaptor.getValue()).isEqualTo(day);
         assertThat(startCaptor.getValue()).isEqualTo(start);
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' has been updated")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' has been updated", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.SUCCESS);
     }
 
@@ -62,7 +65,8 @@ class UpdateStartCommandTest {
 
         //then
         assertThat(commandResult)
-                .hasFieldOrPropertyWithValue("message", "The day '30'.'9' could not be updated because of an exception: test")
+                .hasFieldOrPropertyWithValue("message",
+                        String.format("The day '%d'.'%d' could not be updated because of an exception: test", day, month))
                 .hasFieldOrPropertyWithValue("status", CommandResultStatus.ERROR);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/services/TimesheetManagementServiceTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/services/TimesheetManagementServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
-import java.util.Calendar;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,18 +27,18 @@ class TimesheetManagementServiceTest {
         contextService = mock(TimesheetContextService.class);
         service = new TimesheetManagementService(contextService);
 
-        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
+        month = LocalDateTime.now().getMonthValue();
+        day = LocalDateTime.now().getDayOfMonth();
     }
 
     @Test
     void shouldCallUpdateWorkDayOnTimesheetContextServiceWithProperStartTimeArgument()
             throws TimesheetManagementFailedException {
         //given
-        var startDateTimeBeforeUpdate = LocalDateTime.of(2018, month, day, 8, 0);
-        var startDateTimeToUpdate = LocalDateTime.of(2018, month, day, 9, 15);
+        var startDateTimeBeforeUpdate = LocalDateTime.now();
+        var startDateTimeToUpdate = startDateTimeBeforeUpdate.plusHours(1);
         var startTimeToUpdate = startDateTimeToUpdate.toLocalTime();
-        var endDateTime = LocalDateTime.of(2018, month, day, 16, 45);
+        var endDateTime = startDateTimeBeforeUpdate.plusHours(3);
 
         var workday = WorkDay.builder()
                 .start(startDateTimeBeforeUpdate)
@@ -64,9 +63,9 @@ class TimesheetManagementServiceTest {
     void shouldCallUpdateWorkDayOnTimesheetContextServiceWithProperEndTimeArgument()
             throws TimesheetManagementFailedException {
         //given
-        var startDateTime = LocalDateTime.of(2018, month, day, 7, 45);
-        var endDateTimeBeforeUpdate = LocalDateTime.of(2018, month, day, 16, 0);
-        var endDateTimeToUpdate = LocalDateTime.of(2018, month, day, 17, 15);
+        var startDateTime = LocalDateTime.now();
+        var endDateTimeBeforeUpdate = startDateTime.plusHours(1);
+        var endDateTimeToUpdate = startDateTime.plusHours(2);
         var endTimeToUpdate = endDateTimeToUpdate.toLocalTime();
 
         var workday = WorkDay.builder()
@@ -90,10 +89,10 @@ class TimesheetManagementServiceTest {
 
     @Test
     void shouldThrowATimeSheetManagementFailedExceptionWhenGivenStartTimeIsAfterActualEndTime() {
-        var startDateTimeBeforeUpdate = LocalDateTime.of(2018, month, day, 8, 0);
-        var startDateTimeToUpdate = LocalDateTime.of(2018, month, day, 20, 15);
+        var startDateTimeBeforeUpdate = LocalDateTime.now();
+        var endDateTime = startDateTimeBeforeUpdate.plusHours(1);
+        var startDateTimeToUpdate = endDateTime.plusHours(1);
         var startTimeToUpdate = startDateTimeToUpdate.toLocalTime();
-        var endDateTime = LocalDateTime.of(2018, month, day, 16, 45);
 
         var workday = WorkDay.builder()
                 .start(startDateTimeBeforeUpdate)
@@ -116,9 +115,9 @@ class TimesheetManagementServiceTest {
     @Test
     void shouldThrowATimeSheetManagementFailedExceptionWhenGivenEndTimeIsBeforeActualStartTime() {
         //given
-        var startDateTime = LocalDateTime.of(2018, month, day, 15, 45);
-        var endDateTimeBeforeUpdate = LocalDateTime.of(2018, month, day, 16, 0);
-        var endDateTimeToUpdate = LocalDateTime.of(2018, month, day, 14, 15);
+        var startDateTime = LocalDateTime.now();
+        var endDateTimeBeforeUpdate = startDateTime.plusHours(2);
+        var endDateTimeToUpdate = startDateTime.minusHours(1);
         var endTimeToUpdate = endDateTimeToUpdate.toLocalTime();
 
         var workday = WorkDay.builder()

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/services/TimesheetManagementServiceTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/services/TimesheetManagementServiceTest.java
@@ -27,8 +27,9 @@ class TimesheetManagementServiceTest {
         contextService = mock(TimesheetContextService.class);
         service = new TimesheetManagementService(contextService);
 
-        month = LocalDateTime.now().getMonthValue();
-        day = LocalDateTime.now().getDayOfMonth();
+        var current = LocalDateTime.now();
+        month = current.getMonthValue();
+        day = current.getDayOfMonth();
     }
 
     @Test

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/services/TimesheetManagementServiceTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/services/TimesheetManagementServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
+import java.util.Calendar;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,8 +28,8 @@ class TimesheetManagementServiceTest {
         contextService = mock(TimesheetContextService.class);
         service = new TimesheetManagementService(contextService);
 
-        month = 9;
-        day = 23;
+        month = Calendar.getInstance().get(Calendar.MONTH) + 1;
+        day = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
     }
 
     @Test
@@ -134,8 +135,8 @@ class TimesheetManagementServiceTest {
         //then
         assertThat(thrown)
                 .isInstanceOf(TimesheetManagementFailedException.class)
-                .hasMessage("Provided end time '%s' is before start time '%s' of the given day",
-                        endDateTimeToUpdate, workday.getStart());
+                .hasMessage(String.format("Provided end time '%s' is before start time '%s' of the given day",
+                        endDateTimeToUpdate, workday.getStart()));
     }
 
     @Test

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
@@ -1,28 +1,35 @@
 package com.h8.howlong.admin.utils;
 
-import com.h8.howlong.admin.configuration.*;
-import org.assertj.core.util.*;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import com.h8.howlong.admin.configuration.HowLongAdminCommand;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.time.*;
-import java.time.temporal.*;
-import java.util.stream.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class ArgumentResolverTest {
 
     private LocalTime currentTime;
-    private int currentMonth;
-    private int currentDay;
+    private Integer currentMonth;
+    private Integer currentDay;
 
     @BeforeEach
     void setUp() {
-        currentMonth = LocalDateTime.now().getMonthValue();
-        currentDay = LocalDateTime.now().getDayOfMonth();
-        currentTime = LocalTime.now().truncatedTo(ChronoUnit.SECONDS);
+        var current = LocalDateTime.now();
+        currentMonth = current.getMonthValue();
+        currentDay = current.getDayOfMonth();
+        currentTime = current.toLocalTime().truncatedTo(ChronoUnit.SECONDS);
     }
 
     @Test
@@ -67,7 +74,9 @@ class ArgumentResolverTest {
     void shouldReturnProperDayArgument()
             throws ArgumentResolutionFailedException {
         //given
-        var arguments = Arrays.array(param("day", currentDay), param("month", currentMonth));
+        var arguments = Arrays.array(
+                param("day", currentDay.toString()),
+                param("month", currentMonth.toString()));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -80,7 +89,8 @@ class ArgumentResolverTest {
     @Test
     void shouldThrowAnExceptionForMissingDayArgument() {
         //given
-        var args = Arrays.array("DELETE", param("month", currentMonth));
+        var args = Arrays.array("DELETE",
+                param("month", currentMonth.toString()));
 
         //when
         var a = new ArgumentResolver(args);
@@ -95,7 +105,9 @@ class ArgumentResolverTest {
     void shouldReturnProperMonthArgument()
             throws ArgumentResolutionFailedException {
         //given
-        var arguments = Arrays.array(param("day", currentDay), param("month", currentMonth));
+        var arguments = Arrays.array(
+                param("day", currentDay.toString()),
+                param("month", currentMonth.toString()));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -121,10 +133,11 @@ class ArgumentResolverTest {
 
     @ParameterizedTest(name = "day = {arguments}, month = 9")
     @ValueSource(ints = {0, 31})
-    void shouldThrowAnExceptionForAGivenImproperDayOfAMonth(int day) {
+    void shouldThrowAnExceptionForAGivenImproperDayOfAMonth(Integer day) {
         //given
         var arguments = Arrays.array("List",
-                param("day", day), param("month", 9));
+                param("day", day.toString()),
+                param("month", "9"));
 
         //when
         var a = new ArgumentResolver(arguments);
@@ -137,9 +150,10 @@ class ArgumentResolverTest {
 
     @ParameterizedTest(name = "month = {arguments}")
     @ValueSource(ints = {0, 13})
-    void shouldThrowAnExceptionForAGivenImproperMonthArgument(int month) {
+    void shouldThrowAnExceptionForAGivenImproperMonthArgument(Integer month) {
         //given
-        var arguments = Arrays.array("List", param("month", month));
+        var arguments = Arrays.array("List",
+                param("month", month.toString()));
 
         //when
         var a = new ArgumentResolver(arguments);
@@ -155,9 +169,9 @@ class ArgumentResolverTest {
             throws ArgumentResolutionFailedException {
         //given
         var arguments = Arrays.array("UPDATE",
-                param("day", currentDay),
-                param("month", currentMonth),
-                param("start-time", currentTime));
+                param("day", currentDay.toString()),
+                param("month", currentMonth.toString()),
+                param("start-time", currentTime.toString()));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -171,8 +185,8 @@ class ArgumentResolverTest {
     void shouldThrowAnExceptionForIllegalTimeFormat() {
         //given
         var args = Arrays.array("UPDATE",
-                param("day", currentDay),
-                param("month", currentMonth),
+                param("day", currentDay.toString()),
+                param("month", currentMonth.toString()),
                 param("start-time", "11.11.11"));
 
         //when
@@ -189,9 +203,9 @@ class ArgumentResolverTest {
             throws ArgumentResolutionFailedException {
         //given
         var arguments = Arrays.array("UPDATE",
-                param("day", currentDay),
-                param("month", currentMonth),
-                param("end-time", currentTime));
+                param("day", currentDay.toString()),
+                param("month", currentMonth.toString()),
+                param("end-time", currentTime.toString()));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -201,7 +215,7 @@ class ArgumentResolverTest {
         assertThat(endTime).hasValue(currentTime);
     }
 
-    private String param(String paramName, Object paramValue) {
+    private String param(String paramName, String paramValue) {
         return String.format("--%s=%s", paramName, paramValue);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
@@ -1,36 +1,22 @@
 package com.h8.howlong.admin.utils;
 
-import com.h8.howlong.admin.configuration.HowLongAdminCommand;
-import org.assertj.core.util.Arrays;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import com.h8.howlong.admin.configuration.*;
+import org.assertj.core.util.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
-import java.util.stream.Stream;
+import java.time.*;
+import java.time.temporal.*;
+import java.util.stream.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.*;
 
 class ArgumentResolverTest {
 
     private LocalTime currentTime;
     private int currentMonth;
     private int currentDay;
-
-    static private Stream<Arguments> resolveCommandArgumentsProvider() {
-        return Stream.of(
-                Arguments.of("List", HowLongAdminCommand.LIST),
-                Arguments.of("Update", HowLongAdminCommand.UPDATE),
-                Arguments.of("Delete", HowLongAdminCommand.DELETE)
-        );
-    }
 
     @BeforeEach
     void setUp() {
@@ -69,11 +55,19 @@ class ArgumentResolverTest {
         assertThat(result).isEqualTo(command);
     }
 
+    static private Stream<Arguments> resolveCommandArgumentsProvider() {
+        return Stream.of(
+                Arguments.of("List", HowLongAdminCommand.LIST),
+                Arguments.of("Update", HowLongAdminCommand.UPDATE),
+                Arguments.of("Delete", HowLongAdminCommand.DELETE)
+        );
+    }
+
     @Test
     void shouldReturnProperDayArgument()
             throws ArgumentResolutionFailedException {
         //given
-        var arguments = Arrays.array(String.format("--day=%d", currentDay), String.format("--month=%d", currentMonth));
+        var arguments = Arrays.array(param("day", currentDay), param("month", currentMonth));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -86,7 +80,7 @@ class ArgumentResolverTest {
     @Test
     void shouldThrowAnExceptionForMissingDayArgument() {
         //given
-        var args = Arrays.array("DELETE", String.format("--month=%d", currentMonth));
+        var args = Arrays.array("DELETE", param("month", currentMonth));
 
         //when
         var a = new ArgumentResolver(args);
@@ -101,7 +95,7 @@ class ArgumentResolverTest {
     void shouldReturnProperMonthArgument()
             throws ArgumentResolutionFailedException {
         //given
-        var arguments = Arrays.array(String.format("--day=%d", currentDay), String.format("--month=%d", currentMonth));
+        var arguments = Arrays.array(param("day", currentDay), param("month", currentMonth));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -109,21 +103,6 @@ class ArgumentResolverTest {
 
         //then
         assertThat(monthReturned).isEqualTo(currentMonth);
-    }
-
-    @ParameterizedTest(name = "day = {arguments}, month = 9")
-    @ValueSource(ints = {0, 31})
-    void shouldThrowAnExceptionForAGivenImproperDayOfAMonth(int day) {
-        //given
-        var arguments = Arrays.array("List", String.format("--day=%s", day), "--month=9");
-
-        //when
-        var a = new ArgumentResolver(arguments);
-        var thrown = catchThrowable(a::getDay);
-
-        //then
-        assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
-                .hasMessage(String.format("Day value '%s' is invalid for month '9'", day));
     }
 
     @Test
@@ -140,11 +119,27 @@ class ArgumentResolverTest {
         assertThat(monthReturned).isEqualTo(LocalDate.now().getMonthValue());
     }
 
+    @ParameterizedTest(name = "day = {arguments}, month = 9")
+    @ValueSource(ints = {0, 31})
+    void shouldThrowAnExceptionForAGivenImproperDayOfAMonth(int day) {
+        //given
+        var arguments = Arrays.array("List",
+                param("day", day), param("month", 9));
+
+        //when
+        var a = new ArgumentResolver(arguments);
+        var thrown = catchThrowable(a::getDay);
+
+        //then
+        assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
+                .hasMessage(String.format("Day value '%s' is invalid for month '9'", day));
+    }
+
     @ParameterizedTest(name = "month = {arguments}")
     @ValueSource(ints = {0, 13})
     void shouldThrowAnExceptionForAGivenImproperMonthArgument(int month) {
         //given
-        var arguments = Arrays.array("List", String.format("--month=%s", month));
+        var arguments = Arrays.array("List", param("month", month));
 
         //when
         var a = new ArgumentResolver(arguments);
@@ -159,8 +154,10 @@ class ArgumentResolverTest {
     void shouldReturnProperStartTimeArgument()
             throws ArgumentResolutionFailedException {
         //given
-        var arguments = Arrays.array("UPDATE", String.format("--day=%d", currentDay),
-                String.format("--month=%d", currentMonth), String.format("--start-time=%s", currentTime));
+        var arguments = Arrays.array("UPDATE",
+                param("day", currentDay),
+                param("month", currentMonth),
+                param("start-time", currentTime));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -173,8 +170,10 @@ class ArgumentResolverTest {
     @Test
     void shouldThrowAnExceptionForIllegalTimeFormat() {
         //given
-        var args = Arrays.array("UPDATE", String.format("--day=%d", currentDay),
-                String.format("--month=%d", currentMonth), "--start-time=11.11.11");
+        var args = Arrays.array("UPDATE",
+                param("day", currentDay),
+                param("month", currentMonth),
+                param("start-time", "11.11.11"));
 
         //when
         var a = new ArgumentResolver(args);
@@ -189,8 +188,10 @@ class ArgumentResolverTest {
     void shouldReturnProperEndTimeArgument()
             throws ArgumentResolutionFailedException {
         //given
-        var arguments = Arrays.array("UPDATE", String.format("--day=%d", currentDay),
-                String.format("--month=%d", currentMonth), String.format("--end-time=%s", currentTime));
+        var arguments = Arrays.array("UPDATE",
+                param("day", currentDay),
+                param("month", currentMonth),
+                param("end-time", currentTime));
 
         //when
         var ar = new ArgumentResolver(arguments);
@@ -198,5 +199,9 @@ class ArgumentResolverTest {
 
         //then
         assertThat(endTime).hasValue(currentTime);
+    }
+
+    private String param(String paramName, Object paramValue) {
+        return String.format("--%s=%s", paramName, paramValue);
     }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
@@ -1,57 +1,24 @@
 package com.h8.howlong.admin.utils;
 
-import com.h8.howlong.admin.configuration.HowLongAdminCommand;
-import org.assertj.core.util.Arrays;
-import org.junit.jupiter.api.Test;
+import com.h8.howlong.admin.configuration.*;
+import org.assertj.core.util.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.*;
+import java.util.stream.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.*;
 
 class ArgumentResolverTest {
 
-    @Test
-    void shouldResolveListCommand()
-            throws ArgumentResolutionFailedException {
-        //given
-        var args = Arrays.array("List");
-
-        //when
-        var a = new ArgumentResolver(args);
-        var result = a.getCommand();
-
-        //then
-        assertThat(result).isEqualTo(HowLongAdminCommand.LIST);
-    }
-
-    @Test
-    void shouldResolveUpdateCommand()
-            throws ArgumentResolutionFailedException {
-        //given
-        var args = Arrays.array("Update");
-
-        //when
-        var a = new ArgumentResolver(args);
-        var result = a.getCommand();
-
-        //then
-        assertThat(result).isEqualTo(HowLongAdminCommand.UPDATE);
-    }
-
-    @Test
-    void shouldResolveDeleteCommand()
-            throws ArgumentResolutionFailedException {
-        //given
-        var args = Arrays.array("Delete");
-
-        //when
-        var a = new ArgumentResolver(args);
-        var result = a.getCommand();
-
-        //then
-        assertThat(result).isEqualTo(HowLongAdminCommand.DELETE);
+    static private Stream<Arguments> resolveCommandArgumentsProvider() {
+        return Stream.of(
+                Arguments.of("List", HowLongAdminCommand.LIST),
+                Arguments.of("Update", HowLongAdminCommand.UPDATE),
+                Arguments.of("Delete", HowLongAdminCommand.DELETE)
+        );
     }
 
     @Test
@@ -83,33 +50,19 @@ class ArgumentResolverTest {
         assertThat(day).isEqualTo(30);
     }
 
-    @Test
-    void shouldThrowAnExceptionForDayArgumentAboveUpperBound() {
+    @ParameterizedTest(name = "command = {0}")
+    @MethodSource("resolveCommandArgumentsProvider")
+    void shouldResolveCommand(String commandName, Enum command)
+            throws ArgumentResolutionFailedException {
         //given
-        var args = Arrays.array("LIST", "--day=31","--month=9");
+        var args = Arrays.array(commandName);
 
         //when
         var a = new ArgumentResolver(args);
-        var thrown = catchThrowable(a::getDay);
+        var result = a.getCommand();
 
         //then
-        assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
-                .hasMessage("Day value '31' is invalid for month '9'");
-    }
-
-
-    @Test
-    void shouldThrowAnExceptionForDayArgumentBelowLowerBound() {
-        //given
-        var args = Arrays.array("LIST", "--day=0", "--month=9");
-
-        //when
-        var a = new ArgumentResolver(args);
-        var thrown = catchThrowable(a::getDay);
-
-        //then
-        assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
-                .hasMessage("Day value '0' is invalid for month '9'");
+        assertThat(result).isEqualTo(command);
     }
 
     @Test
@@ -154,32 +107,19 @@ class ArgumentResolverTest {
         assertThat(month).isEqualTo(LocalDate.now().getMonthValue());
     }
 
-    @Test
-    void shouldThrowAnExceptionForMonthArgumentAboveUpperBound() {
+    @ParameterizedTest(name = "day = {arguments}, month = 9")
+    @ValueSource(ints = {0, 31})
+    void shouldThrowAnExceptionForAGivenImproperDayOfAMonth(int day) {
         //given
-        var args = Arrays.array("LIST", "--month=13");
+        var arguments = Arrays.array("List", String.format("--day=%s", day), "--month=9");
 
         //when
-        var a = new ArgumentResolver(args);
-        var thrown = catchThrowable(a::getMonth);
+        var a = new ArgumentResolver(arguments);
+        var thrown = catchThrowable(a::getDay);
 
         //then
         assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
-                .hasMessage("Month value '13' is invalid");
-    }
-
-    @Test
-    void shouldThrowAnExceptionForMonthArgumentBelowLowerBound() {
-        //given
-        var args = Arrays.array("LIST", "--month=0");
-
-        //when
-        var a = new ArgumentResolver(args);
-        var thrown = catchThrowable(a::getMonth);
-
-        //then
-        assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
-                .hasMessage("Month value '0' is invalid");
+                .hasMessage(String.format("Day value '%s' is invalid for month '9'", day));
     }
 
     @Test
@@ -196,20 +136,20 @@ class ArgumentResolverTest {
         assertThat(startTime).hasValue(LocalTime.of(11, 11, 11));
     }
 
-    @Test
-    void shouldReturnProperEndTimeArgument()
-            throws ArgumentResolutionFailedException {
+    @ParameterizedTest(name = "month = {arguments}")
+    @ValueSource(ints = {0, 13})
+    void shouldThrowAnExceptionForAGivenImproperMonthArgument(int month) {
         //given
-        var arguments = Arrays.array("UPDATE", "--month=2", "--day=2", "--end-time=12:12:12");
+        var arguments = Arrays.array("List", String.format("--month=%s", month));
 
         //when
-        var ar = new ArgumentResolver(arguments);
-        var startTime = ar.getEndTime();
+        var a = new ArgumentResolver(arguments);
+        var thrown = catchThrowable(a::getMonth);
 
         //then
-        assertThat(startTime).hasValue(LocalTime.of(12, 12, 12));
+        assertThat(thrown).isInstanceOf(ArgumentResolutionFailedException.class)
+                .hasMessage(String.format("Month value '%d' is invalid", month));
     }
-
 
     @Test
     void shouldThrowAnExceptionForIllegalTimeFormat() {
@@ -225,5 +165,17 @@ class ArgumentResolverTest {
                 .hasMessage("Could not parse 'start-time' argument as LocalTime");
     }
 
+    @Test
+    void shouldReturnProperEndTimeArgument()
+            throws ArgumentResolutionFailedException {
+        //given
+        var arguments = Arrays.array("UPDATE", "--month=2", "--day=2", "--end-time=12:12:12");
 
+        //when
+        var ar = new ArgumentResolver(arguments);
+        var endTime = ar.getEndTime();
+
+        //then
+        assertThat(endTime).hasValue(LocalTime.of(12, 12, 12));
+    }
 }

--- a/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
+++ b/how-long-admin/src/test/java/com/h8/howlong/admin/utils/ArgumentResolverTest.java
@@ -10,8 +10,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Calendar;
+import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 class ArgumentResolverTest {
 
+    private LocalTime currentTime;
     private int currentMonth;
     private int currentDay;
 
@@ -28,6 +30,13 @@ class ArgumentResolverTest {
                 Arguments.of("Update", HowLongAdminCommand.UPDATE),
                 Arguments.of("Delete", HowLongAdminCommand.DELETE)
         );
+    }
+
+    @BeforeEach
+    void setUp() {
+        currentMonth = LocalDateTime.now().getMonthValue();
+        currentDay = LocalDateTime.now().getDayOfMonth();
+        currentTime = LocalTime.now().truncatedTo(ChronoUnit.SECONDS);
     }
 
     @Test
@@ -43,12 +52,6 @@ class ArgumentResolverTest {
         assertThat(thrown)
                 .isInstanceOf(ArgumentResolutionFailedException.class)
                 .hasMessage("Unknown command 'UNKNOWN'");
-    }
-
-    @BeforeEach
-    void setUp() {
-        currentMonth = Calendar.getInstance().get(Calendar.MONTH) + 1;
-        currentDay = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
     }
 
     @ParameterizedTest(name = "command = {0}")
@@ -157,14 +160,14 @@ class ArgumentResolverTest {
             throws ArgumentResolutionFailedException {
         //given
         var arguments = Arrays.array("UPDATE", String.format("--day=%d", currentDay),
-                String.format("--month=%d", currentMonth), "--start-time=11:11:11");
+                String.format("--month=%d", currentMonth), String.format("--start-time=%s", currentTime));
 
         //when
         var ar = new ArgumentResolver(arguments);
         var startTime = ar.getStartTime();
 
         //then
-        assertThat(startTime).hasValue(LocalTime.of(11, 11, 11));
+        assertThat(startTime).hasValue(currentTime);
     }
 
     @Test
@@ -187,13 +190,13 @@ class ArgumentResolverTest {
             throws ArgumentResolutionFailedException {
         //given
         var arguments = Arrays.array("UPDATE", String.format("--day=%d", currentDay),
-                String.format("--month=%d", currentMonth), "--end-time=12:12:12");
+                String.format("--month=%d", currentMonth), String.format("--end-time=%s", currentTime));
 
         //when
         var ar = new ArgumentResolver(arguments);
         var endTime = ar.getEndTime();
 
         //then
-        assertThat(endTime).hasValue(LocalTime.of(12, 12, 12));
+        assertThat(endTime).hasValue(currentTime);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,13 @@
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
@@ -128,6 +135,12 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Hi,

I added some parametrized testing and did minor amendments that we have discussed some time ago. I believe it can me merged, although I am not sure if more tests could be parametrized as follows. Please let me know if any of the following should also be implemented: 

- Update (-Start, -End, -Full)CommandTest.class all look pretty similar to each other. I feel that it could be simplified somehow, couldn't it?

- methods: shouldProduce (-List, -Delete, -UpdateStart, -UpdateEnd, -UpdateFull)Command() of a CommandFactoryTest.class can be squashed into parametrized method test. I know that we have already discussed this but i cannot recall the solution.

- methods: shouldReturnProper(-Start, -End)TimeArgument() could be parametrized if function could be an argument of a parametrized test method.